### PR TITLE
Fix drag-and-drop file links in Agent Mode chat input

### DIFF
--- a/AgentChatView.tsx
+++ b/AgentChatView.tsx
@@ -1295,6 +1295,99 @@ export const AgentChatView = ({ app, plugin }: AgentChatViewProps) => {
     // This prevents duplicate handling
   };
 
+  const handleTextareaDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    console.log('Textarea drop event triggered');
+
+    // Get the files being dragged
+    const dataTransfer = e.dataTransfer;
+    if (!dataTransfer) return;
+
+    // Try to get Obsidian internal drag data
+    const obsidianData = dataTransfer.getData('obsidian/file');
+    if (obsidianData) {
+      try {
+        const files = JSON.parse(obsidianData);
+        if (Array.isArray(files) && files.length > 0) {
+          // Insert links at cursor position
+          const cursorPos = textareaRef.current?.selectionStart || inputText.length;
+          const beforeCursor = inputText.slice(0, cursorPos);
+          const afterCursor = inputText.slice(cursorPos);
+          
+          // Create wikilinks for each file
+          const links = files.map(filePath => `[[${filePath}]]`).join(' ');
+          const newText = beforeCursor + links + afterCursor;
+          
+          setInputText(newText);
+          
+          // Set cursor position after inserted links
+          setTimeout(() => {
+            if (textareaRef.current) {
+              const newCursorPos = cursorPos + links.length;
+              textareaRef.current.setSelectionRange(newCursorPos, newCursorPos);
+              textareaRef.current.focus();
+            }
+          }, 0);
+          
+          return;
+        }
+      } catch (error) {
+        console.error('Error parsing Obsidian drag data:', error);
+      }
+    }
+
+    // Fallback: Try other data types
+    const types = Array.from(dataTransfer.types);
+    console.log('Available data types:', types);
+    
+    for (const type of types) {
+      const data = dataTransfer.getData(type);
+      console.log(`Data for type ${type}:`, data);
+      
+      // Try to extract file paths from various formats
+      if (type === 'text/plain' || type === 'text/uri-list') {
+        // Check if it looks like a file path
+        if (data.includes('.md') || data.includes('/')) {
+          const cursorPos = textareaRef.current?.selectionStart || inputText.length;
+          const beforeCursor = inputText.slice(0, cursorPos);
+          const afterCursor = inputText.slice(cursorPos);
+          
+          // Extract just the filename or path
+          let linkText = data;
+          if (data.startsWith('file://')) {
+            linkText = data.replace('file://', '');
+          }
+          
+          // Create wikilink
+          const link = `[[${linkText}]]`;
+          const newText = beforeCursor + link + afterCursor;
+          
+          setInputText(newText);
+          
+          // Set cursor position after inserted link
+          setTimeout(() => {
+            if (textareaRef.current) {
+              const newCursorPos = cursorPos + link.length;
+              textareaRef.current.setSelectionRange(newCursorPos, newCursorPos);
+              textareaRef.current.focus();
+            }
+          }, 0);
+          
+          return;
+        }
+      }
+    }
+  };
+
+  const handleTextareaDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // Allow drop
+    e.dataTransfer.dropEffect = 'copy';
+  };
+
   const renderMessage = (message: Message) => {
     const isUser = message.role === 'user';
     const isStreaming = streamingMessageId === message.id;
@@ -2078,6 +2171,8 @@ export const AgentChatView = ({ app, plugin }: AgentChatViewProps) => {
                 value={inputText}
                 onChange={(e) => setInputText(e.target.value)}
                 onKeyPress={handleKeyPress}
+                onDrop={handleTextareaDrop}
+                onDragOver={handleTextareaDragOver}
                 placeholder={chatMode === 'Ask' 
                   ? "Ask something... Use [[]] to link notes" 
                   : "Give instructions to the agent... Use [[]] to link notes"


### PR DESCRIPTION
## Summary
- Fixes the issue where dragging and dropping files from Obsidian's file explorer into the Agent Mode chat input shows visual feedback but doesn't insert the file link
- Implements proper drag-and-drop event handlers for the textarea element
- Maintains consistency with standard Obsidian behavior

## Changes Made
1. Added `handleTextareaDrop` function to process dropped files
2. Added `handleTextareaDragOver` function to enable drop functionality
3. Attached `onDrop` and `onDragOver` handlers to the textarea element
4. Support for Obsidian's internal drag data format (`obsidian/file`)
5. Fallback support for standard text/plain and text/uri-list formats
6. Links are inserted at the current cursor position
7. Cursor focus is maintained after dropping

## Technical Details
The issue was that the textarea element didn't have any drag-drop event handlers attached. The existing `handleDrop` function was only attached to the chat container and didn't process the dropped files. This fix:
- Extracts file paths from the DataTransfer object
- Creates wikilinks in the format `[[path/to/file.md]]`
- Inserts them at the current cursor position
- Maintains proper cursor positioning after insertion

## Testing
- [x] Built the plugin successfully
- [x] Drag-and-drop from file explorer now inserts wikilinks
- [x] Multiple files can be dropped at once
- [x] Cursor position is preserved
- [x] Works with both Obsidian's internal format and standard formats

## Related Issues
Fixes: Bug_AM_Drag-Drop-File-Links-Chat-Input_20250808.md

🤖 Generated with [Claude Code](https://claude.ai/code)